### PR TITLE
Fix streaming socket & port to es5

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -386,8 +386,8 @@ class StreamingSocket {
     const rawSocket = createRawSocketObject(host, port);
     let bufferredSize = 0;
 
-    rawSocket.onerror = e => error.put(e);
-    rawSocket.onend = () => data.close();
+    rawSocket.onerror = e => error.output.put(e);
+    rawSocket.onend = () => data.output.close();
     rawSocket.ondata = chunk => {
       var chunkSize = chunk.byteLength
       bufferredSize = bufferredSize + chunkSize
@@ -395,7 +395,7 @@ class StreamingSocket {
       if (bufferredSize >= highWaterMark)
         rawSocket.pause();
 
-      output.put(open => {
+      data.output.put(open => {
         if (open) {
           bufferredSize = bufferredSize - chunkSize
           if (bufferredSize === 0)
@@ -411,7 +411,7 @@ class StreamingSocket {
 }
 
 const mySocketStream = new StreamingSocket("http://example.com", 80);
-print(mySocketStream.data)
+print(mySocketStream.data.input)
 ```
 
 


### PR DESCRIPTION
I fixed a few implementation bugs in your streaming socket example.

I also ported it to ES5.

These are two seperate commits, at least take the first.

The motivation to port to ES5 is to match the rest of the document and to make it easier to read the implementation for those not familiar with ES6.

Of course I understand and appreciate the usage of `yield` and generators for your examples, that's a valid use of ES6.
